### PR TITLE
Setup/route/db reset

### DIFF
--- a/backend/db/db.js
+++ b/backend/db/db.js
@@ -1,10 +1,10 @@
-const knex = require('knex')
-const knexfile = require('./knexfile.js')
+const knex = require('knex');
+const knexfile = require('./knexfile.js');
 
 
 // TO DO: use dependancy injection to create knex instance so db access can be mocked in tests
 // TO DO: use environment variable to determine which knexfile to use
-const db = knex(knexfile.development)
+const db = knex(knexfile.development);
 
 
-module.exports = db
+module.exports = db;

--- a/backend/db/knexfile.js
+++ b/backend/db/knexfile.js
@@ -15,11 +15,11 @@ module.exports = {
       ssl: process.env.PG_SSL ? { rejectUnauthorized: false } : false,
     },
     migrations: {
-      directory: './migrations',
+      directory: (__dirname + '/migrations'),
       tableName: 'migrations',
     },
     seeds: {
-      directory: './seeds',
+      directory: (__dirname + '/seeds')
     },
   },
 

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -10,6 +10,7 @@ const client = require('./clientRoutes');
 const appointment = require('./appointmentRoutes');
 const invoice = require('./invoiceRoutes');
 const address = require('./addressRoutes');
+const runDbReset = require('../services/dbReset');
 
 const router = express.Router();
 
@@ -31,6 +32,14 @@ router.use('/address', address);
 router.get('/test', (req, res) => res.json({
   message: "Seems to work!",
 }));
+
+// database reset route
+router.post('/reset', (req, res) => {
+  runDbReset()
+    .then(() => res.status(200).send('Database reset'))
+    .catch(() => res.status(500).send('Database reset failed'));
+});
+
 
 
 

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -34,7 +34,7 @@ router.get('/test', (req, res) => res.json({
 }));
 
 // database reset route
-router.post('/reset', (req, res) => {
+router.get('/reset', (req, res) => {
   runDbReset()
     .then(() => res.status(200).send('Database reset'))
     .catch(() => res.status(500).send('Database reset failed'));

--- a/backend/services/dbReset.js
+++ b/backend/services/dbReset.js
@@ -1,0 +1,24 @@
+const knex = require('knex');
+const config = require('../db/knexfile');
+
+
+// Initialize knex.
+const db = knex(config.development); // Use the correct configuration for your environment
+
+// Run migrations and then seeds.
+const runDbReset = () => {
+  return new Promise((resolve, reject) => {
+    db.migrate.latest()
+      .then(() => db.seed.run())
+      .then(() => {
+        console.log('Migrations and seeds run successfully');
+        resolve();
+      })
+      .catch(error => {
+        console.error(`Error running migrations or seeds: ${error.message}`);
+        reject(error);
+      });
+  });
+};
+
+module.exports = runDbReset;


### PR DESCRIPTION
set up a route to make database reset easier, just visit: localhost:8080/api/reset in your browser and boom. done. 

- It ensures that:
- If there's a migration pending, it's applied. 
- The seed files are run, reverting to the default data.